### PR TITLE
Fix Markdown in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,9 +20,9 @@
 
   Another aspect are custom simple conditions. The function
   =maybe-print-explanation= is intended to make writing report
-  functions for custom simple conditions easier. See [[*Custom Simple
-  Conditions]] below. =more-conditions= also provides a couple of
-  specific =program-error= s:
+  functions for custom simple conditions easier. See
+  [[*Custom Simple Conditions]] below. =more-conditions= also
+  provides a couple of specific =program-error= s:
   + =program-error=
     + =missing-required-argument=
       + =missing-required-initarg=


### PR DESCRIPTION
There appears to be a bug in Github's parsing!

Adjusting the markdown link to be all on the same source line appears to workaround this. I'm not going to bother investigating furthar and reporting it to Github, corporate doesn't really like me.