### PR TITLE
Similar to PR#3

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,8 +38,8 @@
 
   Finally, =more-conditions= supports embedding documentation
   references in conditions via =condition-references= and the
-  =reference-condition= mixin. See [[*Embedding Documentation References
-  in Conditions]] below.
+  =reference-condition= mixin. See
+  [[*Embedding Documentation References in Conditions]] below.
 
 
   #+ATTR_HTML: :alt "build status image" :title Build Status :align right


### PR DESCRIPTION
Similarly to previous PR #3 , GitHub's renderer apparently requires these links to have the opening and closing delimiters within the same line.

Incidentally, I wonder why you included the edits in a separate commit, rather than using the one in the PR. Isn't it less work to just approve the PR (or merge the commit directly if you're using the CLI), and this also shows the author information in the metadata?